### PR TITLE
Backport to Asterisk 1.8

### DIFF
--- a/configure.ac.diff
+++ b/configure.ac.diff
@@ -1,20 +1,13 @@
---- configure.orig	2018-06-18 20:58:58.614591131 +0000
-+++ configure.ac	2018-06-18 20:59:03.000000000 +0000
-@@ -574,6 +574,8 @@
- AST_EXT_LIB_SETUP([X11], [X11], [x11])
- AST_EXT_LIB_SETUP([ZLIB], [zlib compression], [z])
- 
-+AST_EXT_LIB_SETUP([DFEGRPC], [Dialogflow gRPC], [dfegrpc])
-+
- # check for basic system features and functionality before
- # checking for package libraries
- 
-@@ -2525,6 +2527,8 @@
- AST_EXT_LIB_CHECK([VORBIS], [vorbis], [vorbis_info_init], [vorbis/codec.h], [-lm -lvorbisenc -lvorbisfile])
+--- configure.ac
++++ configure.ac
+@@ -2118,6 +2118,10 @@ else
+ fi
  AST_C_DECLARE_CHECK([VORBIS_OPEN_CALLBACKS], [OV_CALLBACKS_NOCLOSE], [vorbis/vorbisfile.h])
  
++# BEGIN RES_SPEECH_DFE
++AST_EXT_LIB_SETUP([DFEGRPC], [Dialogflow gRPC], [dfegrpc])
 +AST_EXT_LIB_CHECK([DFEGRPC], [dfegrpc], [df_init], [libdfegrpc.h], [-lprotobuf -lgrpc++ -lstdc++])
-+
++# END RES_SPEECH_DFE
  AC_LANG_PUSH(C++)
  
  if test "${USE_VPB}" != "no"; then

--- a/configure.ac.diff
+++ b/configure.ac.diff
@@ -1,11 +1,20 @@
 --- configure.ac
 +++ configure.ac
-@@ -2118,6 +2118,10 @@ else
+@@ -464,6 +464,9 @@ AST_EXT_LIB_SETUP([VORBIS], [Vorbis], [vorbis])
+ AST_EXT_LIB_SETUP([VPB], [Voicetronix API], [vpb])
+ AST_EXT_LIB_SETUP([X11], [X11], [x11])
+ AST_EXT_LIB_SETUP([ZLIB], [zlib compression], [z])
++# BEGIN RES_SPEECH_DFE
++AST_EXT_LIB_SETUP([DFEGRPC], [Dialogflow gRPC], [dfegrpc])
++# END RES_SPEECH_DFE
+ 
+ # check for basic system features and functionality before
+ # checking for package libraries
+@@ -2118,6 +2121,9 @@ else
  fi
  AST_C_DECLARE_CHECK([VORBIS_OPEN_CALLBACKS], [OV_CALLBACKS_NOCLOSE], [vorbis/vorbisfile.h])
  
 +# BEGIN RES_SPEECH_DFE
-+AST_EXT_LIB_SETUP([DFEGRPC], [Dialogflow gRPC], [dfegrpc])
 +AST_EXT_LIB_CHECK([DFEGRPC], [dfegrpc], [df_init], [libdfegrpc.h], [-lprotobuf -lgrpc++ -lstdc++])
 +# END RES_SPEECH_DFE
  AC_LANG_PUSH(C++)

--- a/makeopts.in.diff
+++ b/makeopts.in.diff
@@ -1,0 +1,10 @@
+--- makeopts.in
++++ makeopts.in
+@@ -314,3 +314,7 @@ TINFO_DIR=@TINFO_DIR@
+ # if poll is not present, let the makefile know.
+ POLL_AVAILABLE=@HAS_POLL@
+ TIMERFD_INCLUDE=@TIMERFD_INCLUDE@
++# BEGIN RES_SPEECH_DFE
++DFEGRPC_INCLUDE=@DFEGRPC_INCLUDE@
++DFEGRPC_LIB=@DFEGRPC_LIB@
++# END RES_SPEECH_DFE

--- a/menuselect-deps.in.diff
+++ b/menuselect-deps.in.diff
@@ -1,0 +1,9 @@
+--- build_tools/menuselect-deps.in
++++ build_tools/menuselect-deps.in
+@@ -71,3 +71,6 @@ JANSSON=@PBX_JANSSON@
+ YAJL=@PBX_YAJL@
+ EXPAT=@PBX_EXPAT@
+ 
++# BEGIN RES_SPEECH_DFE
++DFEGRPC=@PBX_DFEGRPC@
++# END RES_SPEECH_DFE


### PR DESCRIPTION
Backport the dialogflow speech module to 1.8
In addition, add some sentinel values to the patches for the build files. This allows the build file changes to be removed cleanly (so they can be re-added).