### PR TITLE
Add call logging & recording facilities

### DIFF
--- a/res/res_speech_gdfe.c
+++ b/res/res_speech_gdfe.c
@@ -939,7 +939,7 @@ static int load_config(int reload)
 			ast_string_field_set(conf, call_log_location, val);
 		}
 
-		conf->enable_call_logs = 0;
+		conf->enable_call_logs = 1;
 		val = ast_variable_retrieve(cfg, "general", "enable_call_logs");
 		if (!ast_strlen_zero(val)) {
 			conf->enable_call_logs = ast_true(val);

--- a/res/res_speech_gdfe.c
+++ b/res/res_speech_gdfe.c
@@ -886,6 +886,12 @@ static int load_config(int reload)
 			ast_string_field_set(conf, call_log_location, val);
 		}
 
+		conf->enable_call_logs = 0;
+		val = ast_variable_retrieve(cfg, "general", "enable_call_logs");
+		if (!ast_strlen_zero(val)) {
+			conf->enable_call_logs = ast_true(val);
+		}
+
 		/* swap out the configs */
 #ifdef ASTERISK_13_OR_LATER
 		ao2_wrlock(config);

--- a/res/res_speech_gdfe.c
+++ b/res/res_speech_gdfe.c
@@ -958,7 +958,7 @@ static void gdf_log_call_event(struct gdf_pvt *pvt, enum gdf_call_log_type type,
 	timeval_now = ast_tvnow();
 	ast_localtime(&timeval_now, &tm_now, NULL);
 
-	ast_strftime(char_now, sizeof(char_now), "%FT%TZ", &tm_now);
+	ast_strftime(char_now, sizeof(char_now), "%FT%T.%q%z", &tm_now);
 
 	if (type == CALL_LOG_TYPE_SESSION) {
 		char_type = "SESSION";

--- a/res/res_speech_gdfe.c
+++ b/res/res_speech_gdfe.c
@@ -467,19 +467,6 @@ static int gdf_stop_recognition(struct ast_speech *speech, struct gdf_pvt *pvt)
 	return 0;
 }
 
-#define MAX_DEBUG_LEN	350
-static char *gdf_hexdump(unsigned char buf[], int size, char *s /* destination */)
-{
-	char *p;
-	int f;
-
-	for (p = s, f = 0; f < size && f < MAX_DEBUG_LEN; f++, p += 3) {
-		sprintf(p, "%02X ", (unsigned char)buf[f]);
-	}
-	return(s);
-}
-
-
 /* speech structure is locked */
 static int gdf_write(struct ast_speech *speech, void *data, int len)
 {

--- a/res/res_speech_gdfe.c
+++ b/res/res_speech_gdfe.c
@@ -63,6 +63,7 @@
 #define GDF_PROP_SESSION_ID_NAME	"session_id"
 #define GDF_PROP_PROJECT_ID_NAME	"project_id"
 #define GDF_PROP_LANGUAGE_NAME		"language"
+#define GDF_PROP_LOG_CONTEXT		"log_context"
 #define VAD_PROP_VOICE_THRESHOLD	"voice_threshold"
 #define VAD_PROP_VOICE_DURATION		"voice_duration"
 #define VAD_PROP_SILENCE_DURATION	"silence_duration"
@@ -507,6 +508,10 @@ static int gdf_change(struct ast_speech *speech, const char *name, const char *v
 	} else if (!strcasecmp(name, GDF_PROP_LANGUAGE_NAME)) {
 		ast_mutex_lock(&pvt->lock);
 		ast_string_field_set(pvt, language, value);
+		ast_mutex_unlock(&pvt->lock);
+	} else if (!strcasecmp(name, GDF_PROP_LOG_CONTEXT)) {
+		ast_mutex_lock(&pvt->lock);
+		ast_string_field_set(pvt, log_context, value);
 		ast_mutex_unlock(&pvt->lock);
 	} else if (!strcasecmp(name, VAD_PROP_VOICE_THRESHOLD)) {
 		int i;

--- a/res/res_speech_gdfe.c
+++ b/res/res_speech_gdfe.c
@@ -93,12 +93,12 @@ struct gdf_config {
 	int vad_voice_minimum_duration;
 	int vad_silence_minimum_duration;
 
-	int enableCallLogs;
+	int enable_call_logs;
 
 	AST_DECLARE_STRING_FIELDS(
 		AST_STRING_FIELD(service_key);
 		AST_STRING_FIELD(endpoint);
-		AST_STRING_FIELD(callLogLocation);
+		AST_STRING_FIELD(call_log_location);
 	);
 };
 
@@ -726,10 +726,10 @@ static int load_config(int reload)
 			}
 		}
 
-		ast_string_field_set(conf, callLogLocation, "/var/log/dialogflow/${CONTEXT}/${STRFTIME(,,%%Y/%%m/%%d/%%H)}/");
-		val = ast_variable_retrieve(cfg, "general", "callLogLocation");
+		ast_string_field_set(conf, call_log_location, "/var/log/dialogflow/${CONTEXT}/${STRFTIME(,,%%Y/%%m/%%d/%%H)}/");
+		val = ast_variable_retrieve(cfg, "general", "call_log_location");
 		if (!ast_strlen_zero(val)) {
-			ast_string_field_set(conf, callLogLocation, val);
+			ast_string_field_set(conf, call_log_location, val);
 		}
 
 		/* swap out the configs */
@@ -797,8 +797,8 @@ static char *gdfe_show_config(struct ast_cli_entry *e, int cmd, struct ast_cli_a
 			ast_cli(a->fd, "vad_voice_threshold = %d\n", config->vad_voice_threshold);
 			ast_cli(a->fd, "vad_voice_minimum_duration = %d\n", config->vad_voice_minimum_duration);
 			ast_cli(a->fd, "vad_silence_minimum_duration = %d\n", config->vad_silence_minimum_duration);
-			ast_cli(a->fd, "enableCallLogs = %s\n", AST_CLI_YESNO(config->enableCallLogs));
-			ast_cli(a->fd, "callLogLocation = %s\n", config->callLogLocation);
+			ast_cli(a->fd, "enable_call_logs = %s\n", AST_CLI_YESNO(config->enable_call_logs));
+			ast_cli(a->fd, "call_log_location = %s\n", config->call_log_location);
 			ao2_ref(config, -1);
 		} else {
 			ast_cli(a->fd, "Unable to retrieve configuration\n");

--- a/res/res_speech_gdfe.c
+++ b/res/res_speech_gdfe.c
@@ -93,9 +93,12 @@ struct gdf_config {
 	int vad_voice_minimum_duration;
 	int vad_silence_minimum_duration;
 
+	int enableCallLogs;
+
 	AST_DECLARE_STRING_FIELDS(
 		AST_STRING_FIELD(service_key);
 		AST_STRING_FIELD(endpoint);
+		AST_STRING_FIELD(callLogLocation);
 	);
 };
 
@@ -723,6 +726,12 @@ static int load_config(int reload)
 			}
 		}
 
+		ast_string_field_set(conf, callLogLocation, "/var/log/dialogflow/${CONTEXT}/${STRFTIME(,,%%Y/%%m/%%d/%%H)}/");
+		val = ast_variable_retrieve(cfg, "general", "callLogLocation");
+		if (!ast_strlen_zero(val)) {
+			ast_string_field_set(conf, callLogLocation, val);
+		}
+
 		/* swap out the configs */
 #ifdef ASTERISK_13_OR_LATER
 		ao2_wrlock(config);
@@ -788,6 +797,8 @@ static char *gdfe_show_config(struct ast_cli_entry *e, int cmd, struct ast_cli_a
 			ast_cli(a->fd, "vad_voice_threshold = %d\n", config->vad_voice_threshold);
 			ast_cli(a->fd, "vad_voice_minimum_duration = %d\n", config->vad_voice_minimum_duration);
 			ast_cli(a->fd, "vad_silence_minimum_duration = %d\n", config->vad_silence_minimum_duration);
+			ast_cli(a->fd, "enableCallLogs = %s\n", AST_CLI_YESNO(config->enableCallLogs));
+			ast_cli(a->fd, "callLogLocation = %s\n", config->callLogLocation);
 			ao2_ref(config, -1);
 		} else {
 			ast_cli(a->fd, "Unable to retrieve configuration\n");

--- a/res/res_speech_gdfe.c
+++ b/res/res_speech_gdfe.c
@@ -400,7 +400,7 @@ static void start_call_log(struct gdf_pvt *pvt)
 
 		ast_mkdir(ast_str_buffer(path), 0644);
 
-		ast_str_append(&path, 0, pvt->session_id);
+		ast_str_append(&path, 0, "%s.LOG", pvt->session_id);
 
 		log_file = fopen(ast_str_buffer(path), "w");
 		if (log_file) {


### PR DESCRIPTION
- Create a mechanism to create a call log and save recordings of calls as they occur. Call logging is done as a file of json lines in a configurable location.
- Add session variables so the dialplan can control recording/logging location and provide context in the log files.
- Change the grammar name format to include the project ID