### PR TITLE
VAD changes

### DIFF
--- a/res/res_speech_gdfe.c
+++ b/res/res_speech_gdfe.c
@@ -648,7 +648,7 @@ static int gdf_write(struct ast_speech *speech, void *data, int len)
 
 	cur_duration += datams;
 
-	avg_level = calculate_audio_level((short *)data, len);
+	avg_level = calculate_audio_level((short *)data, datasamples);
 	if (avg_level >= threshold) {
 		if (vad_state != VAD_STATE_SPEAK) {
 			change_duration += datams;

--- a/res/res_speech_gdfe.c
+++ b/res/res_speech_gdfe.c
@@ -804,7 +804,7 @@ static void calculate_log_file_basename(struct gdf_pvt *pvt)
 
 static void mkdir_log_path(struct gdf_pvt *pvt)
 {
-	ast_mkdir(pvt->call_log_path, 0644);
+	ast_mkdir(pvt->call_log_path, 0755);
 }
 
 static struct ast_str *build_log_related_filename_to_thread_local_str(struct gdf_pvt *pvt, int include_utterance_counter, const char *type, const char *extension)

--- a/res/res_speech_gdfe.c
+++ b/res/res_speech_gdfe.c
@@ -1358,7 +1358,7 @@ static int load_config(int reload)
 			ast_string_field_set(conf, endpoint, val);
 		}
 
-		conf->vad_voice_threshold = 512;
+		conf->vad_voice_threshold = 1024;
 		val = ast_variable_retrieve(cfg, "general", "vad_voice_threshold");
 		if (!ast_strlen_zero(val)) {
 			int i;
@@ -1369,7 +1369,7 @@ static int load_config(int reload)
 			}
 		}
 
-		conf->vad_voice_minimum_duration = 40; /* ms */
+		conf->vad_voice_minimum_duration = 100; /* ms */
 		val = ast_variable_retrieve(cfg, "general", "vad_voice_minimum_duration");
 		if (!ast_strlen_zero(val)) {
 			int i;
@@ -1397,7 +1397,7 @@ static int load_config(int reload)
 			}
 		}
 
-		conf->endpointer_cache_audio_pretrigger_ms = 60;
+		conf->endpointer_cache_audio_pretrigger_ms = 100;
 		val = ast_variable_retrieve(cfg, "general", "endpointer_cache_audio_pretrigger_ms");
 		if (!ast_strlen_zero(val)) {
 			int i;


### PR DESCRIPTION
Modify the VAD logic to cache audio while it's deciding if enough audio has occurred. In addition cache a little more than that (to provide a pre-speech buffer). Then flush all that to dialogflow once it thinks speech has started.

With this change, can make the VAD less sensitive but still get the entire utterance.
Fix the level calculation being wrong since we changed to getting slinear.
Also fix the fact that only root can look at the logs.