### PR TITLE
Fix warning on compile for start_recognition_on_start

### DIFF
--- a/res/res_speech_gdfe.c
+++ b/res/res_speech_gdfe.c
@@ -768,7 +768,7 @@ static int gdf_write(struct ast_speech *speech, void *data, int len)
 	int mulaw_len;
 	char *mulaw;
 	int i;
-	int start_recognition_on_start;
+	int start_recognition_on_start = 0;
 	struct gdf_config *cfg;
 
 	datasamples = len / sizeof(short); /* 2 bytes per sample for slin */;


### PR DESCRIPTION
Needs a default value